### PR TITLE
Install gdb to riscv-vela-image-core.

### DIFF
--- a/recipes-core/images/riscv-vela-image-core.bb
+++ b/recipes-core/images/riscv-vela-image-core.bb
@@ -5,3 +5,7 @@ IMAGE_FEATURES += "debug-tweaks"
 LICENSE = "MIT"
 
 inherit core-image
+
+IMAGE_INSTALL:append = " \
+    gdb \
+"


### PR DESCRIPTION
Fixes riscv-vela/meta-riscv-vela#28
